### PR TITLE
Add Manifest.in to include *.md files in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.md 
+
+

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(*names, **kwargs):
     ) as fp:
         return fp.read()
 
-CURRENT_VERSION = '0.2.2'
+CURRENT_VERSION = '0.2.3'
 
 setup(
     name='pysvg-py3',


### PR DESCRIPTION
Hi @alorence ,

I was just attempting to package this up for conda and ran into an issue with the package on pypi. The source does not have the README.md file which is called by setup.py.  This triggers an error in the conda build system.

This PR simply adds a manifest file telling setuptools to include the *.MD.

Do you think you could rebuild and upload to pypi?

thanks,
zach cp