### PR TITLE
add 3.6 and 3.7 to the classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Topic :: Multimedia :: Graphics",
     ]
 )


### PR DESCRIPTION
Hi @alorence ,

I have run into an issue building this package with conda-build on python 3.6. I know this is not an issue with the package as `pip install` works just fine. I believe `conda-build` is using the classifier field to construct the build matrix and is not building 3.6.  

Do you think you can rebuild/submit this package to pypi with an updated classifiers field?

Thank You,
zach cp